### PR TITLE
Fixed README.md file with correct characters for minilogo

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Each option creates the source of the font to be built. One or more sources are 
 ### Option `-btflminilogo`
 
 - loads generic bitmap the source file
-- the bitmap is scalled and renders to glyphs `[\\]^_`
+- the bitmap is scalled and renders to glyphs `[\]^_`
 - use as a craft name or pilot name to display in OSD
 - valid file formats
   - png


### PR DESCRIPTION
I noticed a mistake in the README.md file. The characters for the minilogo were listed incorrectly.